### PR TITLE
devel/ccache needs to be installed for a successful build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -157,7 +157,7 @@ init)	# install some required packages (using pkg_add)
 	fi
 
 	exec ${SUDO} pkg_add -a 'python%2.7' 'gmake' 'g++%4.9' 'git' \
-		'curl' 'cmake' \
+		'curl' 'cmake' 'ccache' \
 		${_ccache} \
 		${_llvm}
 	;;


### PR DESCRIPTION
Without this, one gets errors like:

```
  = note: /home/ltratt/tmp/build-rust/build_dir/bin/cc[2]: ccache: not found
```

when building beta